### PR TITLE
Add example Helm chart and build pipeline

### DIFF
--- a/.github/workflows/build_chart.yml
+++ b/.github/workflows/build_chart.yml
@@ -1,0 +1,28 @@
+name: build and release chart
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -1,0 +1,44 @@
+name: build and push container
+
+on:
+  push:
+    branches: [ "main" ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 **.py[cod]
 __pycache__/
 __pycache__/database.cpython-311.pyc
+.idea
+.DS_Store

--- a/charts/learnloop/Chart.yaml
+++ b/charts/learnloop/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: learnloop
+description: LearnLoop
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/learnloop/templates/deployment.yaml
+++ b/charts/learnloop/templates/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: learnloop
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      app: learnloop
+  replicas: 1
+  revisionHistoryLimit: 3
+  template:
+    metadata:
+      labels:
+        app: learnloop
+    spec:
+      containers:
+        - name: learnloop
+          image: "{{ .Values.image }}:{{ .Values.tag }}"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+          envFrom:
+            - secretRef:
+                name: learnloop-secret
+          {{- if .Values.azure }}
+          volumeMounts:
+            - name: secrets-store-inline
+              mountPath: "/etc/secrets"
+              readOnly: true
+          {{- end }}
+
+      {{- if .Values.azure }}
+      volumes:
+        - name: secrets-store-inline
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "learnloop-secretproviderclass"
+      {{- end }}

--- a/charts/learnloop/templates/ingress.yaml
+++ b/charts/learnloop/templates/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: learnloop-ingress
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    kubernetes.io/ingress.class: "{{ .Values.ingressClass }}"
+spec:
+  tls:
+    - hosts:
+        - "{{ .Values.hostname }}"
+  rules:
+    - host: "{{ .Values.hostname }}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: learnloop
+                port:
+                  number: 80

--- a/charts/learnloop/templates/secretproviderclass.yaml
+++ b/charts/learnloop/templates/secretproviderclass.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.azure }}
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: learnloop-secretproviderclass
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  provider: azure
+  secretObjects:
+    - secretName: learnloop-secret
+      type: Opaque
+      data:
+      {{- range .Values.azure.secrets }}
+        - objectName: {{ .name }}
+          key: {{ .key }}
+      {{- end }}
+  parameters:
+    usePodIdentity: "false"
+    useVMManagedIdentity: "true"
+    userAssignedIdentityID: "{{ .Values.azure.clientId }}"
+    keyvaultName: "{{ .Values.azure.keyvaultName }}"
+    cloudName: AzurePublicCloud
+    objects: |
+      array:
+      {{- range .Values.azure.secrets }}
+        - |
+          objectName: {{ .name }}
+          objectType: secret
+      {{- end }}
+    resourceGroup: "{{ .Values.azure.resourceGroup }}"
+    subscriptionId: "{{ .Values.azure.subscriptionId }}"
+    tenantId: "{{ .Values.azure.tenantId }}"
+  {{- end }}

--- a/charts/learnloop/templates/service.yaml
+++ b/charts/learnloop/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: learnloop
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+  selector:
+    app: learnloop

--- a/charts/learnloop/values.yaml
+++ b/charts/learnloop/values.yaml
@@ -1,0 +1,15 @@
+hostname: learnloop.local
+ingressClass: nginx
+image: learnloop
+tag: latest
+
+azure:
+  keyvaultName: keyvaultName
+  resourceGroup: resourceGroupName
+  subscriptionId: subscriptionId
+  tenantId: tenantId
+  clientId: clientId
+  identityName: identityName
+  secrets:
+    - name: learnloop-connection-string
+      key: CONNECTIONSTRING # TODO: check this and add other secrets


### PR DESCRIPTION
Here's an example Helm chart and a build pipeline for GitHub actions that builds both the container and chart. Note that:
- The pipelines are now set up to pushes both of these to GitHub, which might not be what you want (also since the GitHub repo is currently private)
- Some secrets will need to be added, see the TODO in values.yaml. The current setup allows secrets to be retrieved from a key vault in Azure